### PR TITLE
crc32_test: test C and ASM for various alignments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ CFLAGS+=-m64 -g -O2 -mcpu=power8 -mpower8-vector -Wall
 ASFLAGS=-m64 -g
 LDFLAGS=-m64 -g -static
 
+SHELL=/bin/bash
+
 # Ethernet CRC
 #CRC=0x04C11DB7
 
@@ -40,7 +42,6 @@ PROGS_ALTIVEC=barrett_reduction_test \
 	vec_barrett_reduction_test \
 	vec_final_fold_test \
 	vec_final_fold2_test \
-	vec_crc32_test \
 	vec_crc32_bench \
 	crc32_two_implementations
 
@@ -75,6 +76,10 @@ $(CRC32_CONSTANTS_OBJS) : %.o : %.c Makefile
 crc32_constants.h: crc32_constants
 	$(EMULATOR) ./crc32_constants $(OPTIONS) $(CRC) > crc32_constants.h
 
+vec_crc32_c.o: vec_crc32.c crc32_constants.h
+	$(CC) -c $(CFLAGS) \
+		-D CRC32_FUNCTION=crc32_vpmsum_c \
+		vec_crc32.c -o $@
 crc32.o: crc32.S crc32_constants.h
 crc32_stress.o: crc32_stress.c crc32_constants.h
 crc32_test.o: crc32_test.c crc32_constants.h
@@ -82,15 +87,14 @@ crc32_wrapper.o: crc32_wrapper.c crc32_constants.h
 
 slice_by_8_bench: crc32_bench.o
 
-crc32_test: crc32_test.o crcmodel.o crc32.o crc32_wrapper.o
+crc32_test: crc32_test.o crcmodel.o crc32.o crc32_wrapper.o vec_crc32_c.o
 crc32_bench: crc32_bench.o crc32.o crc32_wrapper.o
 crc32_stress: crc32_stress.o crcmodel.o crc32.o crc32_wrapper.o
 
 vec_crc32.o: vec_crc32.c crc32_constants.h
-vec_crc32_test: crc32_test.o crcmodel.o vec_crc32.o
 vec_crc32_bench: crc32_bench.o vec_crc32.o
 
-vec_crc32_test vec_crc32_bench:
+vec_crc32_bench:
 	$(CC) $(LDFLAGS) $^ -o $@
 
 # This is an example of multiple crc32 polynomials being used
@@ -119,5 +123,14 @@ crc32k_wrapper.o crc32k.o:
 
 crc32_two_implementations: crc32k_wrapper.o crc32k.o vec_crc32_ethernet.o
 
+# implementation has boundaries on datasizes 16 and 256, 32768 so ensure coverage and correctness
+test: crc32_test
+	set -e ; \
+	for len in `seq 0 257`  32767 32768 32769 65535 65536 65537 ; do \
+		./crc32_test  $${RANDOM} $$len $${RANDOM} ; \
+	done ; \
+
 clean:
 	rm -f crc32_constants.h crc32k_constants.h crc32_ethernet_constants.h *.o $(PROGS) $(PROGS_ALTIVEC)
+
+.PHONY: clean test all


### PR DESCRIPTION
This rolls vec_crc32_test into the crc32_test by comparing the
reference, ASM and C vpmsum CRC32 implementations.

A Makefile target of test is added to test the boundary conditions
of the implementations.

Figured it needed a good test suite.

Code coverage examined with:

make clean
make crc32_constants
make CFLAGS='-fprofile-arcs -ftest-coverage' LDFLAGS=-fprofile-arcs crc32_test
make test
gcov vec_crc32_c.c
more vec_crc32.c.gcov